### PR TITLE
feat: add gin context into droplet context

### DIFF
--- a/wrapper/gin/gin.go
+++ b/wrapper/gin/gin.go
@@ -12,6 +12,8 @@ import (
 	"net/http"
 )
 
+var GinContextKey = "gin_ctx"
+
 func Wraps(handler droplet.Handler, opts ...wrapper.SetWrapOpt) func(*gin.Context) {
 	return func(ctx *gin.Context) {
 		opt := &wrapper.WrapOptBase{}
@@ -21,6 +23,7 @@ func Wraps(handler droplet.Handler, opts ...wrapper.SetWrapOpt) func(*gin.Contex
 
 		dCtx := droplet.NewContext()
 		dCtx.SetContext(ctx.Request.Context())
+		dCtx.Set(GinContextKey, ctx)
 
 		ret, _ := droplet.NewPipe().
 			Add(middleware.NewHttpInfoInjectorMiddleware(middleware.HttpInfoInjectorOption{


### PR DESCRIPTION
Add gin context into droplet context. So that we can get gin.Context in API handler.